### PR TITLE
dev/check_probtrackx

### DIFF
--- a/NFACT_PP/__main__.py
+++ b/NFACT_PP/__main__.py
@@ -12,6 +12,7 @@ from NFACT_PP.nfactpp_check_functions import (
     return_list_of_subjects_from_file,
     list_of_subjects_from_directory,
     check_arguments,
+    check_ptx_options_are_valid,
 )
 
 if __name__ == "__main__":
@@ -58,8 +59,10 @@ if __name__ == "__main__":
         try:
             arg["ptx_options"] = read_file_to_list(arg["ptx_options"])
             arg["ptx_options"] = [arg.strip() for arg in arg["ptx_options"]]
+
         except Exception as e:
             error_and_exit(False, f"Unable to read ptx_options text file due to {e}")
+        check_ptx_options_are_valid(arg["ptx_options"])
 
     if arg["hcp_stream"]:
         hcp_stream_main(arg)

--- a/NFACT_PP/nfactpp_check_functions.py
+++ b/NFACT_PP/nfactpp_check_functions.py
@@ -1,7 +1,9 @@
 import os
 import glob
 import pathlib
+import re
 from NFACT_PP.nfactpp_utils_functions import colours, read_file_to_list, error_and_exit
+from NFACT_PP.nfactpp_probtrackx_functions import get_probtrack2_arguments
 
 
 def directory_contains_subjects(study_folder_path: str) -> bool:
@@ -308,3 +310,30 @@ def check_surface_arguments(seed: list, roi: list) -> None:
         )
         return True
     return False
+
+
+def check_ptx_options_are_valid(ptx_options: list):
+    """
+    Function to check that ptx options
+    valid options. Errors out if
+    any are not valid options
+
+    Parameters
+    ----------
+    ptx_options: list
+       list of user defined options
+
+    Returns
+    -------
+    None
+    """
+
+    check_out = get_probtrack2_arguments()
+    probtrack_args = re.findall(r"-.*?\t", check_out)
+    stripped_args = [arg.rstrip("\t") for arg in probtrack_args]
+    probtrack_args = sum([arg.split(",") for arg in stripped_args], [])
+    [
+        error_and_exit(False, f"{arg} is not a probtrackx2 option")
+        for arg in ptx_options
+        if arg not in probtrack_args
+    ]

--- a/NFACT_PP/nfactpp_probtrackx_functions.py
+++ b/NFACT_PP/nfactpp_probtrackx_functions.py
@@ -280,3 +280,28 @@ def seeds_to_ascii(surfin: str, roi: str, surfout: str) -> None:
             False,
             f"FSL surf2surf failure due to {run.stderr}. Unable to create asc surface",
         )
+
+
+def get_probtrack2_arguments():
+    """
+    Function to get probtrack2
+    arguments to check that user input
+    is valid
+
+    Parameters
+    ----------
+    None
+
+    Returns
+    -------
+    help_arguments: str
+        string of help arguments
+    """
+    import subprocess
+
+    try:
+        help_arguments = subprocess.run(["probtrackx2", "--help"], capture_output=True)
+    except subprocess.CalledProcessError as error:
+        error_and_exit(False, f"Error in calling surf2surf: {error}")
+
+    return help_arguments.stderr.decode("utf-8")


### PR DESCRIPTION
added in function to check that probtrack2 arguments are valid. Does so by checking stdoutput from probtrackx and seeing if probtrack2 users options are in list.
1) Calls probtrack2 --help and captures output
2) Turns to a list
3) Checks that users input is in list, otherwise errors out